### PR TITLE
Fix some markdown syntax for GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-#Storm Adaptive Background
+# Storm Adaptive Background
 
 Find the dominant colours in an image and set one as the background colour of a DOM element
 
-##Usage
+## Usage
 ```
 npm install storm-adaptive-background
 ```
@@ -12,12 +12,13 @@ var StormAdaptiveBackground = require('storm-adaptive-background')
 StormAdaptiveBackground.init('js-adaptive-bg',  {minWidth: 768});
 ```
 
-###Options
-	- target, String, CSS selector denoting target elements to apply the background colour
-	- normaliseTextColour, boolean, default: false, to normalise the color of the parent text if background color is too dark or too light
-	- normalisedTextColours, Object, default: {dark: '#000', light: '#fff'} text colors used when background is either too dark/light
-	- lumaClasses
-	- callback, Function, called after colour background is set
+### Options
+
+- `target`, String, CSS selector denoting target elements to apply the background colour
+- `normaliseTextColour`, boolean, default: false, to normalise the color of the parent text if background color is too dark or too light
+- `normalisedTextColours`, Object, default: {dark: '#000', light: '#fff'} text colors used when background is either too dark/light
+- `lumaClasses`
+- `callback`, Function, called after colour background is set
 	
-###Credits
+### Credits
 A browserify object compositional refactoring of https://github.com/briangonzalez/jquery.adaptive-backgrounds.js


### PR DESCRIPTION
Current README is ok for npm page ( https://www.npmjs.com/package/storm-adaptive-background ), but GitHub can't parse some syntax. This fixes for viewing README at GitHub.

## Before

![image](https://user-images.githubusercontent.com/377137/29521429-73148b08-86c0-11e7-8f29-e9ba33485a5e.png)

## After

![image](https://user-images.githubusercontent.com/377137/29521446-85d825b0-86c0-11e7-89f0-f95153d190c7.png)
